### PR TITLE
Creates role with task that installs pylxca before every task

### DIFF
--- a/playbooks/config/config.yml
+++ b/playbooks/config/config.yml
@@ -2,4 +2,5 @@
   hosts: localhost
   connection: local
   roles:
-    - { role: lenovo.lxca-config }
+    - pre
+    - lenovo.lxca-config

--- a/playbooks/inventory/inventory.yml
+++ b/playbooks/inventory/inventory.yml
@@ -2,4 +2,5 @@
   hosts: localhost
   connection: local
   roles:
-    - { role: lenovo.lxca-inventory }
+    - pre
+    - lenovo.lxca-inventory

--- a/roles/pre/tasks/main.yml
+++ b/roles/pre/tasks/main.yml
@@ -1,0 +1,5 @@
+# Installs the pylxca python library that is going to be used by the pylxca_module
+- name: Install PyLXCA dependency
+  pip:
+    name: pylxca
+  tags: always


### PR DESCRIPTION
This PR creates a new role that will be executed before other roles. The _pre_ role executes a task that will install the **pylxca** python library.

- This step removes the requirement of installing [lenovo/pylxca](https://github.com/lenovo/pylxca).
- This change also gives support to the use of these playbooks on **Ansible Tower** or inside **CloudForms Embedded Ansible** because on that environments we can not assume that the pylxca library would be installed.